### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/generated/workshops-source/iSEEWorkshop2020/.github/workflows/build_check_deploy.yaml
+++ b/generated/workshops-source/iSEEWorkshop2020/.github/workflows/build_check_deploy.yaml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Publish to Registry
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: docker.pkg.github.com/isee/iseeworkshop2020/iseeworkshop2020:latest
           username: ${{ github.actor }}

--- a/generated/workshops-source/iSEEWorkshopEuroBioc2020/.github/workflows/build_check_deploy.yaml
+++ b/generated/workshops-source/iSEEWorkshopEuroBioc2020/.github/workflows/build_check_deploy.yaml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Publish to Registry
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: docker.pkg.github.com/isee/iseeworkshopeurobioc2020/iseeworkshopeurobioc2020:latest
           username: ${{ github.actor }}

--- a/old-generated/workshops-source/iSEEWorkshop2020/.github/workflows/build_check_deploy.yaml
+++ b/old-generated/workshops-source/iSEEWorkshop2020/.github/workflows/build_check_deploy.yaml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Publish to Registry
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: docker.pkg.github.com/isee/iseeworkshop2020/iseeworkshop2020:latest
           username: ${{ github.actor }}

--- a/old-generated/workshops-source/iSEEWorkshopEuroBioc2020/.github/workflows/build_check_deploy.yaml
+++ b/old-generated/workshops-source/iSEEWorkshopEuroBioc2020/.github/workflows/build_check_deploy.yaml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Publish to Registry
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: docker.pkg.github.com/isee/iseeworkshopeurobioc2020/iseeworkshopeurobioc2020:latest
           username: ${{ github.actor }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore